### PR TITLE
Fix config.yml

### DIFF
--- a/data/テスト（お店）/config.yml
+++ b/data/テスト（お店）/config.yml
@@ -1,3 +1,3 @@
-category:　テスト（お店）
+category: テスト（お店）
 name: テスト（お店）
 dataType: location


### PR DESCRIPTION
category の後に全角スペース入ってエラーになっていたので修正。

* `category:<全角スペース>テスト（お店）` 
↓
* `category:<半角スペース>テスト（お店）`
