### PR TITLE
ポータルサイトの事務局名の修正

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -187,7 +187,7 @@
   <a class="text-link white" href="https://www.city.yaizu.lg.jp/city-info/digital-dx/smartcity/association.html" target="_blank" rel="noopener noreferrer"><p>焼津市スマートシティ推進協議会</p></a>
 </div>
 <div class="footer_left_cnt">
-<p class="sub_txt">(事務局:焼津市行政経営部ＤＸ推進課)</p>
+<p class="sub_txt">(事務局:焼津市企画部スマートシティ課)</p>
 <address>
 <p>郵便番号：425-8502<br>
 静岡県焼津市本町2丁目16番32号（市役所本庁舎3階）</p>


### PR DESCRIPTION
@hayakawa3573 事務局がDX推進課のままでしたので、修正しました。よろしくお願いします。